### PR TITLE
Add sparkbq to package list

### DIFF
--- a/webtech.md
+++ b/webtech.md
@@ -202,6 +202,7 @@ Web Services
 -   <pkg>rwars</pkg> retrieve and reformat data from the [Star Wars API (SWAPI)](https://swapi.co/).
 -   <pkg>slackr</pkg> ([GitHub](https://github.com/hrbrmstr/slackr)) is a client for Slack.com messaging platform.
 -   <github>dmpe/SlideShaRe</github> (not on CRAN) is a client for Slideshare.
+-   <pkg>sparkbq</pkg> ([GitHub](https://github.com/miraisolutions/sparkbq)): Google BigQuery Support for sparklyr.
 -   <github>dgrtwo/stackr</github> (not on CRAN): An unofficial wrapper for the read-only features of the [Stack Exchange API](https://api.stackexchange.com/).
 -   <pkg>telegram</pkg> ([GitHub](https://github.com/lbraglia/telegram)) connects with the Telegram Bot API.
 -   <pkg>trelloR</pkg> ([GitHub](https://github.com/jchrom/trelloR)) connects to the [Trello API](https://developers.trello.com/).

--- a/webtech.md
+++ b/webtech.md
@@ -171,6 +171,7 @@ Web Services
 
 -   *Wikipedia*: <pkg>WikipediR</pkg> ([GitHub](https://github.com/Ironholds/WikipediR)) is a wrapper for the MediaWiki API, aimed particularly at the Wikimedia 'production' wikis, such as Wikipedia. <github>chgrl/rwikidata</github> and <pkg>WikidataR</pkg> ([GitHub](https://github.com/Ironholds/WikidataR)) can request data from [Wikidata.org](https://www.wikidata.org/wiki/Wikidata:Main_Page), the free knowledgebase. <pkg>wikipediatrend</pkg> ([GitHub](https://github.com/petermeissner/wikipediatrend)) provides access to Wikipedia page access statistics. <pkg>WikiSocio</pkg> can retrieve contributor lists and revision data. <pkg>WikidataQueryServiceR</pkg> is a client for the [Wikidata Query Service](https://query.wikidata.org/).
 -   <pkg>bigrquery</pkg> ([GitHub](https://github.com/r-dbi/bigrquery)): An interface to Google's bigquery.
+-   <pkg>sparkbq</pkg> ([GitHub](https://github.com/miraisolutions/sparkbq)): Google BigQuery support for sparklyr.
 -   <pkg>colourlovers</pkg> ([GitHub](https://github.com/leeper/colourlovers)) extracts colors and multi-color patterns from [COLOURlovers](http://www.colourlovers.com/), for use in creating R graphics color palettes.
 -   <pkg>cymruservices</pkg> queries [Team Cymru](http://www.team-cymru.com/) web security services.
 -   <pkg>datamart</pkg>: Provides an S4 infrastructure for unified handling of internal datasets and web based data sources. Examples include dbpedia, eurostat and sourceforge.
@@ -202,7 +203,6 @@ Web Services
 -   <pkg>rwars</pkg> retrieve and reformat data from the [Star Wars API (SWAPI)](https://swapi.co/).
 -   <pkg>slackr</pkg> ([GitHub](https://github.com/hrbrmstr/slackr)) is a client for Slack.com messaging platform.
 -   <github>dmpe/SlideShaRe</github> (not on CRAN) is a client for Slideshare.
--   <pkg>sparkbq</pkg> ([GitHub](https://github.com/miraisolutions/sparkbq)): Google BigQuery Support for sparklyr.
 -   <github>dgrtwo/stackr</github> (not on CRAN): An unofficial wrapper for the read-only features of the [Stack Exchange API](https://api.stackexchange.com/).
 -   <pkg>telegram</pkg> ([GitHub](https://github.com/lbraglia/telegram)) connects with the Telegram Bot API.
 -   <pkg>trelloR</pkg> ([GitHub](https://github.com/jchrom/trelloR)) connects to the [Trello API](https://developers.trello.com/).


### PR DESCRIPTION
Hi,
I added the package sparkbq (a Sparklyr extension package to connect to Google BigQuery - https://cran.r-project.org/web/packages/sparkbq/index.html) to `webtech.md`.

When using the latest available version of pandoc (2.2.3.1) I noticed that all the 'RIGHT SINGLE QUOTATION MARK' characters (U+2019),  i.e. `’` are converted into 'APOSTROPHE' characters (U+0027), i.e. `'`, in `README.md`, `WebTechnologies.ctv` and `WebTechnlogies.html`.

Therefore I decided to commit only `webtech.md`. Let me know if I should commit the other files as they are, or which version of pandoc I should use.

Thanks,
Nicola